### PR TITLE
Loading spinner now activates only for one

### DIFF
--- a/src/components/adminPage/e-commerce/products/availableProducts/InstantUpdateProduct.jsx
+++ b/src/components/adminPage/e-commerce/products/availableProducts/InstantUpdateProduct.jsx
@@ -1,23 +1,40 @@
 import React from "react";
 import { useDispatch } from "react-redux";
 import { useAdmin } from "../../../../../app/store";
-import { updateProduct } from "../../../../../features";
+import { setRequestId, updateProduct } from "../../../../../features";
 import { SpinCircle, Toogle } from "../../../../../utils";
 
 const InstantUpdateProduct = ({ value, id, field }) => {
-  const { isLoading } = useAdmin();
+  const [enabled, setEnabled] = React.useState(value); // Updating the local state based on toogle value
+  const {
+    isLoading,
+    request: { id: toogleId },
+  } = useAdmin();
   const dispatch = useDispatch();
 
-  const onToggle = (val) => {
+  const onToggle = (val, toggleId) => {
     const payload = { [field]: val };
+    dispatch(setRequestId(toggleId));
     dispatch(updateProduct({ payload, id }));
+    setEnabled(val);
   };
+
+  const wait = isLoading && toogleId && toogleId === `${id}${field}`;
   return (
-    <div className="flex items-center ">
-      {isLoading && (
-        <SpinCircle className={value ? `text-rose-500` : `text-emerald-500`} />
+    <div className="relative w-[5.5rem] ">
+      {wait && (
+        <SpinCircle
+          className={`${
+            enabled ? `text-emerald-500` : `text-rose-500`
+          } absolute inset-y-0 right-0`}
+        />
       )}
-      <Toogle value={value} onToggle={onToggle} loading={isLoading} />
+      <Toogle
+        value={enabled}
+        onToggle={onToggle}
+        loading={wait}
+        toggleId={`${id}${field}`}
+      />
     </div>
   );
 };

--- a/src/features/AdminSlice.js
+++ b/src/features/AdminSlice.js
@@ -20,10 +20,14 @@ import {
   createProductFulfilled,
   updateProduct,
   updateProductFullfilled,
+  setRequestId,
 } from "./reducers/AdminReducers";
 
 const initialState = {
   isLoading: false,
+  request: {
+    id: null,
+  },
   response: {
     isSuccess: false,
     isError: false,
@@ -54,6 +58,8 @@ const AdminSlice = createSlice({
     openProductForm,
     closeProductForm,
     filterProduct,
+
+    setRequestId,
 
     setSidebarOpen: (state, action) => {
       state.isSidebarOpen = action.payload;

--- a/src/features/index.js
+++ b/src/features/index.js
@@ -79,4 +79,5 @@ export const {
   closeCategoryForm,
   openProductForm,
   closeProductForm,
+  setRequestId,
 } = AdminSlice.actions;

--- a/src/features/reducers/AdminReducers.js
+++ b/src/features/reducers/AdminReducers.js
@@ -136,6 +136,10 @@ const getEssentialFields = (Object) => {
   return rest;
 };
 
+export const setRequestId = (state, action) => {
+  state.request.id = action.payload;
+};
+
 // Fetch Product
 export const fetchAllProducts = createAsyncThunk(
   "admin/product/fetchProducts",

--- a/src/utils/Toogle.jsx
+++ b/src/utils/Toogle.jsx
@@ -6,11 +6,12 @@ const Toogle = ({
   value = false,
   onToggle = () => {},
   loading = false,
+  toggleId,
 }) => {
   const [enabled, setEnabled] = useState(value);
   const handleChange = (val) => {
     setEnabled(val);
-    onToggle(val);
+    onToggle(val, toggleId);
   };
 
   return (
@@ -21,7 +22,7 @@ const Toogle = ({
       className={`${
         enabled ? "bg-emerald-500" : "bg-rose-500"
       } relative inline-flex h-6 w-11 items-center rounded-full ${
-        loading ? `!opacity-75` : `!opacity-100`
+        loading ? `!opacity-90` : `!opacity-100`
       }`}
     >
       <span className="sr-only">{text}</span>


### PR DESCRIPTION
 ### Fixes
 - Loading spinner on every buttom while updating only one is fixed
 - Spinner color issue fixed
 - Now while enabling a toggler, spinner color is green and while disabling a toggler, spinner color is red
 - Spinner location is changed from left to right of the toggle and fixed awkard expand while loading
###  Changes
 - Added a request object to fix the toggle issue
 - To identify the the unique toggler a toggleId prop is sent to "Toogle" Component
### Screenshots
- Spinner colour is red while disabling ![Screenshot-from-2022-11-29-17-57-46.png](https://i.postimg.cc/52xWtDXW/Screenshot-from-2022-11-29-17-57-46.png)
- Spinner colour is green while enabling ![Screenshot-from-2022-11-29-17-58-13.png](https://i.postimg.cc/2y8XYNH0/Screenshot-from-2022-11-29-17-58-13.png)
### Resolves issue 
- This PR closes #6 